### PR TITLE
Fixed harded value in pvc.yml

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -33,7 +33,7 @@
         console_url: "https://console-openshift-console.{{ route_subdomain }}"
 
     - name: login as super user with token on OpenShift 4
-      command: "oc login --token={{ token }}  --server={{ server }} --insecure-skip-tls-verify={{ insecure_skip_tls_verify }}"
+      command: "oc login --token='{{ token }}'  --server={{ server }} --insecure-skip-tls-verify={{ insecure_skip_tls_verify }}"
       when:
        - token is defined
        - token is not none

--- a/ansible/roles/solution-explorer/files/pvc.yml
+++ b/ansible/roles/solution-explorer/files/pvc.yml
@@ -8,5 +8,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  storageClassName: gp2
   volumeMode: Filesystem


### PR DESCRIPTION
Removed hard-coded value gp2 from PVC - this makes the PVC go to the default SC instead, which would do nicely and will work regardless of what SCs are defined.  Added quotes around token for login to work around some issues.